### PR TITLE
Ignore uniqSetWithForEach in safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function doesForEachActuallyWork() {
 		ret = el;
 	});
 
-	return ret;
+	return ret === true;
 }
 
 if ('Set' in global) {


### PR DESCRIPTION
Safari doesn’t recognize iterable argument in set constructor.
It is simpler to fall back to `uniqSet` than use `uniqSetWithForEach`.
## 

Fixes #6
